### PR TITLE
Keep modules enabled when WEBPACK_VERSION is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var es2015 = require('babel-preset-es2015');
-var IS_WEBPACK1 = /^1\./.test(process.env.WEBPACK_VERSION);
+var IS_WEBPACK1 = !process.env.WEBPACK_VERSION || /^1\./.test(process.env.WEBPACK_VERSION);
 
 module.exports = !IS_WEBPACK1
   ? es2015.buildPreset(null, {modules: false})

--- a/loose.js
+++ b/loose.js
@@ -1,6 +1,6 @@
 'use strict';
 var es2015 = require('babel-preset-es2015');
-var IS_WEBPACK1 = /^1\./.test(process.env.WEBPACK_VERSION);
+var IS_WEBPACK1 = !process.env.WEBPACK_VERSION || /^1\./.test(process.env.WEBPACK_VERSION);
 
 var modules = !IS_WEBPACK1 ? false : 'commonjs';
 module.exports = es2015.buildPreset(null, {loose: true, modules: modules});


### PR DESCRIPTION
After updating to `1.3.0`, the `modules` option is disabled when `WEBPACK_VERSION` is undefined. This does not seem like the desired behaviour (and is a breaking change from `1.2.1`).

This should resolve this checking for this condition and making sure that `modules` are enabled by default.